### PR TITLE
[gen_initramfs_list] Replace find -printf with stat. JB#36243

### DIFF
--- a/initfs/scripts/gen_initramfs_list.sh
+++ b/initfs/scripts/gen_initramfs_list.sh
@@ -89,7 +89,7 @@ print_mtime() {
 	local my_mtime="0"
 
 	if [ -e "$1" ]; then
-		my_mtime=$(find "$1" -printf "%T@\n" | sort -r | head -n 1)
+		my_mtime=$(find "$1" | xargs stat -c%Y | sort -r | head -n 1)
 	fi
 
 	echo "# Last modified: ${my_mtime}" >> ${output}
@@ -171,7 +171,7 @@ dir_filelist() {
 	${dep_list}header "$1"
 
 	srcdir=$(echo "$1" | sed -e 's://*:/:g')
-	dirlist=$(find "${srcdir}" -printf "%p %m %U %G\n")
+	dirlist=$(find "${srcdir}" | xargs stat -c"%n %a %u %g")
 
 	# If $dirlist is only one line, then the directory is empty
 	if [  "$(echo "${dirlist}" | wc -l)" -gt 1 ]; then


### PR DESCRIPTION
Busybox find doesn't support -printf. This replicates the behaviour
using xargs and stat. The timestamp precision is reduced because stat
doesn't support fractional timestamps.