### PR TITLE
[initramfs] Do not add timestamp in gzipped rootfs. JB#60103

### DIFF
--- a/initfs/scripts/moslo-build.sh
+++ b/initfs/scripts/moslo-build.sh
@@ -426,6 +426,6 @@ if [ ! -z $USE_LZ4 ]; then
 	lz4 -f -l -12 --favor-decSpeed $WORK_DIR/rootfs.cpio $WORK_DIR/rootfs.cpio.lz4
 	echo Build is ready at $WORK_DIR/rootfs.cpio.lz4
 else
-	gzip -f  $WORK_DIR/rootfs.cpio
+	gzip -n -f $WORK_DIR/rootfs.cpio
 	echo Build is ready at $WORK_DIR/rootfs.cpio.gz
 fi


### PR DESCRIPTION
The gzip -n option leaves out the original name and _timestamp_ from the compressed file, making the build reproducible.